### PR TITLE
Add import statement for json_sanitize in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ pip install ofunctions.json_sanitize
 
 Usage:
 ```
+from ofunctions.json_sanitize import json_sanitize
 my_json = {'some.name': 'some\tvalue'}
 my_santized_json = json_sanitize(my_json)
 ```


### PR DESCRIPTION
Currently, the ofunctions documentation omits the import statement for json_sanitize. This means that if a user scrolls down to the appropriate section without checking other code snippets provided, they will think it's `from ofunctions import json_sanitize` when it's actually `from ofunctions.json_sanitize import json_sanitize`. This pull request corrects this omission, ensuring reduced errors and mistakes for the future.